### PR TITLE
updated and renamed metafolio.de to saschadiercks.de

### DIFF
--- a/sites/saschadiercks.de.md
+++ b/sites/saschadiercks.de.md
@@ -1,6 +1,6 @@
 ---
-title: 'metafolio.de'
-url: 'http://metafolio.de'
+title: 'saschadiercks.de'
+url: 'https://saschadiercks.de'
 tags: ['sites', 'designer', 'frontend developer']
 nsfw: false
 rss: false


### PR DESCRIPTION
metafolio.de has been redirected to saschadiercks.de so this update reflects those changes in the repo too.